### PR TITLE
Add per-session combat log file

### DIFF
--- a/src/AwesomeWotlkLib/CMakeLists.txt
+++ b/src/AwesomeWotlkLib/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(
 		"Hooks.h" "Hooks.cpp"
 		"Misc.h" "Misc.cpp"
 		"BugFixes.h" "BugFixes.cpp"
+		"CombatLog.h" "CombatLog.cpp"
 		"MSDF.h" "MSDF.cpp"
 		"MSDFValidator.h" "MSDFUtils.h" "MSDFShaders.h"
 		"MSDFCache.h" "MSDFCache.cpp"

--- a/src/AwesomeWotlkLib/CombatLog.cpp
+++ b/src/AwesomeWotlkLib/CombatLog.cpp
@@ -1,0 +1,54 @@
+// CombatLog.cpp
+// Per-session combat-log file.
+//
+// WoW 3.3.5a opens "Logs\WoWCombatLog.txt" through the ANSI file API (CreateFileA) and
+// appends, so every session lands in one growing file. This detours CreateFileA and rewrites
+// that single path to a per-session name:
+//
+//     Logs\<YYYY-MM-DD-HH.MM.SS> WoWCombatLog.txt
+//
+// i.e. one file per game launch, matching the Ascension/Epoch client output.
+//
+// The redirect is on the ANSI variant on purpose: the 3.3.5a Wow.exe imports only CreateFileA
+// for file I/O (no CreateFileW, no fopen), so a CreateFileW hook would never be invoked.
+
+#include "CombatLog.h"
+#include "Hooks.h"
+#include <windows.h>
+#include <stdio.h>
+#include <string.h>
+
+namespace {
+HANDLE(WINAPI* CreateFileAFn)(LPCSTR, DWORD, DWORD, LPSECURITY_ATTRIBUTES, DWORD, DWORD, HANDLE) = CreateFileA;
+
+HANDLE WINAPI CreateFileA_hk(LPCSTR name, DWORD access, DWORD share, LPSECURITY_ATTRIBUTES sa,
+                             DWORD disp, DWORD flags, HANDLE tmpl)
+{
+    const char* hit;
+    // Match the combat-log file specifically (require both "Logs" and the file name) so we
+    // never touch screenshots, WTF, WoWChatLog.txt, etc.
+    if (name && strstr(name, "Logs") && (hit = strstr(name, "WoWCombatLog.txt"))) {
+        static char stamp[40] = { 0 };          // built once per process == one file per launch
+        if (!stamp[0]) {
+            SYSTEMTIME t; GetLocalTime(&t);
+            sprintf(stamp, "%04d-%02d-%02d-%02d.%02d.%02d ",
+                    t.wYear, t.wMonth, t.wDay, t.wHour, t.wMinute, t.wSecond);
+        }
+        char buf[MAX_PATH];
+        size_t pre = (size_t)(hit - name);      // length of the "...\Logs\" prefix
+        if (pre + strlen(stamp) + sizeof("WoWCombatLog.txt") < sizeof(buf)) {
+            memcpy(buf, name, pre);
+            buf[pre] = 0;
+            strcat(buf, stamp);
+            strcat(buf, "WoWCombatLog.txt");
+            return CreateFileAFn(buf, access, share, sa, disp, flags, tmpl);
+        }
+    }
+    return CreateFileAFn(name, access, share, sa, disp, flags, tmpl);
+}
+}
+
+void CombatLog::initialize()
+{
+    Hooks::Detour(&CreateFileAFn, CreateFileA_hk);
+}

--- a/src/AwesomeWotlkLib/CombatLog.cpp
+++ b/src/AwesomeWotlkLib/CombatLog.cpp
@@ -1,41 +1,48 @@
 // CombatLog.cpp
 // Per-session combat-log file.
 //
-// WoW 3.3.5a opens "Logs\WoWCombatLog.txt" through the ANSI file API (CreateFileA) and
-// appends, so every session lands in one growing file. This detours CreateFileA and rewrites
-// that single path to a per-session name:
+// WoW 3.3.5a opens "Logs\WoWCombatLog.txt" and appends, so every session lands in one growing
+// file. This detours the file-open call and rewrites that single path to a per-session name:
 //
 //     Logs\<YYYY-MM-DD-HH.MM.SS> WoWCombatLog.txt
 //
 // i.e. one file per game launch, matching the Ascension/Epoch client output.
 //
-// The redirect is on the ANSI variant on purpose: the 3.3.5a Wow.exe imports only CreateFileA
-// for file I/O (no CreateFileW, no fopen), so a CreateFileW hook would never be invoked.
+// Both the ANSI (CreateFileA) and wide (CreateFileW) variants are hooked, because different
+// 3.3.5a client builds open the combat log through different APIs. A given Wow.exe uses one or
+// the other; hooking both makes the redirect work regardless of which. The single shared
+// timestamp keeps every open within a session pointed at the same file.
 
 #include "CombatLog.h"
 #include "Hooks.h"
 #include <windows.h>
 #include <stdio.h>
 #include <string.h>
+#include <wchar.h>
 
 namespace {
-HANDLE(WINAPI* CreateFileAFn)(LPCSTR, DWORD, DWORD, LPSECURITY_ATTRIBUTES, DWORD, DWORD, HANDLE) = CreateFileA;
+// Session timestamp "YYYY-MM-DD-HH.MM.SS " built once per process == one file per launch.
+const char* sessionStamp()
+{
+    static char s[40] = { 0 };
+    if (!s[0]) {
+        SYSTEMTIME t; GetLocalTime(&t);
+        sprintf(s, "%04d-%02d-%02d-%02d.%02d.%02d ",
+                t.wYear, t.wMonth, t.wDay, t.wHour, t.wMinute, t.wSecond);
+    }
+    return s;
+}
 
+// ---- ANSI ----
+HANDLE(WINAPI* CreateFileAFn)(LPCSTR, DWORD, DWORD, LPSECURITY_ATTRIBUTES, DWORD, DWORD, HANDLE) = CreateFileA;
 HANDLE WINAPI CreateFileA_hk(LPCSTR name, DWORD access, DWORD share, LPSECURITY_ATTRIBUTES sa,
                              DWORD disp, DWORD flags, HANDLE tmpl)
 {
     const char* hit;
-    // Match the combat-log file specifically (require both "Logs" and the file name) so we
-    // never touch screenshots, WTF, WoWChatLog.txt, etc.
     if (name && strstr(name, "Logs") && (hit = strstr(name, "WoWCombatLog.txt"))) {
-        static char stamp[40] = { 0 };          // built once per process == one file per launch
-        if (!stamp[0]) {
-            SYSTEMTIME t; GetLocalTime(&t);
-            sprintf(stamp, "%04d-%02d-%02d-%02d.%02d.%02d ",
-                    t.wYear, t.wMonth, t.wDay, t.wHour, t.wMinute, t.wSecond);
-        }
+        const char* stamp = sessionStamp();
         char buf[MAX_PATH];
-        size_t pre = (size_t)(hit - name);      // length of the "...\Logs\" prefix
+        size_t pre = (size_t)(hit - name);
         if (pre + strlen(stamp) + sizeof("WoWCombatLog.txt") < sizeof(buf)) {
             memcpy(buf, name, pre);
             buf[pre] = 0;
@@ -46,9 +53,34 @@ HANDLE WINAPI CreateFileA_hk(LPCSTR name, DWORD access, DWORD share, LPSECURITY_
     }
     return CreateFileAFn(name, access, share, sa, disp, flags, tmpl);
 }
+
+// ---- wide ----
+HANDLE(WINAPI* CreateFileWFn)(LPCWSTR, DWORD, DWORD, LPSECURITY_ATTRIBUTES, DWORD, DWORD, HANDLE) = CreateFileW;
+HANDLE WINAPI CreateFileW_hk(LPCWSTR name, DWORD access, DWORD share, LPSECURITY_ATTRIBUTES sa,
+                             DWORD disp, DWORD flags, HANDLE tmpl)
+{
+    const wchar_t* hit;
+    if (name && wcsstr(name, L"Logs") && (hit = wcsstr(name, L"WoWCombatLog.txt"))) {
+        const char* stamp = sessionStamp();          // ASCII-only -> widen by simple cast
+        wchar_t wstamp[40]; size_t n = 0;
+        while (stamp[n] && n < 39) { wstamp[n] = (wchar_t)(unsigned char)stamp[n]; ++n; }
+        wstamp[n] = 0;
+        wchar_t buf[MAX_PATH];
+        size_t pre = (size_t)(hit - name);
+        if (pre + n + (sizeof("WoWCombatLog.txt")) < (sizeof(buf) / sizeof(wchar_t))) {
+            wmemcpy(buf, name, pre);
+            buf[pre] = 0;
+            wcscat(buf, wstamp);
+            wcscat(buf, L"WoWCombatLog.txt");
+            return CreateFileWFn(buf, access, share, sa, disp, flags, tmpl);
+        }
+    }
+    return CreateFileWFn(name, access, share, sa, disp, flags, tmpl);
+}
 }
 
 void CombatLog::initialize()
 {
     Hooks::Detour(&CreateFileAFn, CreateFileA_hk);
+    Hooks::Detour(&CreateFileWFn, CreateFileW_hk);
 }

--- a/src/AwesomeWotlkLib/CombatLog.h
+++ b/src/AwesomeWotlkLib/CombatLog.h
@@ -1,0 +1,4 @@
+#pragma once
+namespace CombatLog {
+void initialize();
+}

--- a/src/AwesomeWotlkLib/Entry.cpp
+++ b/src/AwesomeWotlkLib/Entry.cpp
@@ -1,4 +1,5 @@
 #include "BugFixes.h"
+#include "CombatLog.h"
 #include "D3D.h"
 #include "Camera.h"
 #include "CommandLine.h"
@@ -50,6 +51,7 @@ void OnAttach() {
 	D3D::initialize();
 	Camera::initialize();
 	BugFixes::initialize();
+	CombatLog::initialize();
 	CommandLine::initialize();
 	Inventory::initialize();
 	Item::initialize();


### PR DESCRIPTION
## Summary

Adds a small `CombatLog` module so each session gets its own combat-log file instead of appending to a single `Logs\WoWCombatLog.txt`. On `/combatlog` the file is created as:

```
Logs\<YYYY-MM-DD-HH.MM.SS> WoWCombatLog.txt
```

one file per game launch (timestamp = session start), matching the per-session naming other 3.3.5a clients produce - which is what log parsers/uploaders expect for clean session boundaries.

## Problem

In stock 3.3.5a the combat-log path is hardcoded and always opened in append mode, so every raid night accumulates into one ever-growing file that has to be split by hand before it can be parsed per-session. Addons can't help - they can only toggle `LoggingCombat()`, not rename or relocate the file - so the split has to happen at the native layer.

## Both file-open APIs are hooked

Different 3.3.5a client builds open the combat log through different file APIs - some via the ANSI `CreateFileA`, some via the wide `CreateFileW`. A given `Wow.exe` uses one or the other. Hooking only one variant misses the log on builds that use the other (and silently falls back to the single-file append). So this detours **both** `CreateFileA` and `CreateFileW`; whichever the running client uses, the redirect fires. A shared per-process timestamp keeps every open pointed at the same session file.

## Implementation

- `CombatLog.cpp` / `CombatLog.h`: `CreateFileA` + `CreateFileW` detours installed via the existing `Hooks::Detour` helper, wired into the Detours transaction in `Entry.cpp` alongside the other modules.
- **Precise match:** rewrites only when the path contains both `Logs` and `WoWCombatLog.txt`, so screenshots / `WTF` / `WoWChatLog.txt` are never touched.
- **One file per launch:** the timestamp is formatted once per process; every open within a session (including `/combatlog` off/on) resolves to the same file.
- **Fully pass-through:** forwards to the original API with all access/share/disposition/flags unchanged, so there's no re-entrancy and no change to how the game writes or flushes - only the filename at open time differs.

## Testing

- Built Win32 / Release (VS2022).
- Verified in-client on a live 3.3.5a realm: `/combatlog` creates `Logs\<timestamp> WoWCombatLog.txt`, no plain `WoWCombatLog.txt` is written while active, and combat data flushes in incrementally during play (~49 KB increments over sustained combat - the game's normal flush cadence is unchanged, which matters for log uploaders that tail the file).
- Additive and self-contained; other modules are unaffected.

